### PR TITLE
Bump Hugo version to 0.147.0 for PaperMod compatibility

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.139.4
+      HUGO_VERSION: 0.147.0
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
PaperMod requires Hugo >= 0.146.0.